### PR TITLE
fix: event saving without dance-style and required validations added

### DIFF
--- a/components/TForm.vue
+++ b/components/TForm.vue
@@ -8,9 +8,12 @@
         :label="getLabel(field)"
         @input="(val) => onFieldChange(field, val)"
       />
-    </div>
-    <div v-if="error" class="text-red-500 py-4 text-right">
-      {{ error.message }}
+      <div
+        v-if="error && error.field === field.name"
+        class="text-red-500 py-4 text-right"
+      >
+        {{ error.message }}
+      </div>
     </div>
     <slot name="bottom" />
     <div
@@ -76,12 +79,12 @@ export default {
       default: '',
     },
     eventError: {
-      type: String,
-      default: '',
+      type: Object,
+      default: () => ({}),
     },
   },
   data: () => ({
-    error: false,
+    error: {},
   }),
   computed: {
     visibleFields() {
@@ -109,7 +112,8 @@ export default {
   watch: {
     eventError(newValue, _) {
       this.error = {
-        message: newValue,
+        message: newValue.message,
+        field: newValue.field,
       }
     },
   },

--- a/components/TForm.vue
+++ b/components/TForm.vue
@@ -75,6 +75,10 @@ export default {
       type: String,
       default: '',
     },
+    eventError: {
+      type: String,
+      default: '',
+    },
   },
   data: () => ({
     error: false,
@@ -100,6 +104,13 @@ export default {
       }
 
       return fields.map((f) => ({ ...f, ...this.fieldConfig }))
+    },
+  },
+  watch: {
+    eventError(newValue, _) {
+      this.error = {
+        message: newValue,
+      }
     },
   },
   methods: {

--- a/components/TForm.vue
+++ b/components/TForm.vue
@@ -8,11 +8,13 @@
         :label="getLabel(field)"
         @input="(val) => onFieldChange(field, val)"
       />
-      <div
-        v-if="error && error.field === field.name"
-        class="text-red-500 py-4 text-right"
-      >
-        {{ error.message }}
+      <div v-for="error in errors" :key="error.field">
+        <div
+          v-if="error.field === field.name"
+          class="text-red-500 py-4 text-right"
+        >
+          {{ error.message }}
+        </div>
       </div>
     </div>
     <slot name="bottom" />
@@ -78,13 +80,13 @@ export default {
       type: String,
       default: '',
     },
-    eventError: {
-      type: Object,
-      default: () => ({}),
+    errors: {
+      type: Array,
+      default: () => [],
     },
   },
   data: () => ({
-    error: {},
+    error: false,
   }),
   computed: {
     visibleFields() {
@@ -107,14 +109,6 @@ export default {
       }
 
       return fields.map((f) => ({ ...f, ...this.fieldConfig }))
-    },
-  },
-  watch: {
-    eventError(newValue, _) {
-      this.error = {
-        message: newValue.message,
-        field: newValue.field,
-      }
     },
   },
   methods: {

--- a/pages/events/_id/edit.vue
+++ b/pages/events/_id/edit.vue
@@ -17,6 +17,7 @@
         vertical
         :show-remove="!!item.id"
         :show-copy="!!item.id"
+        :event-error="eventError"
         submit-label="Save"
         class="bg-white p-4 space-y-4"
         @copy="copyItem"
@@ -49,6 +50,7 @@ export default {
   },
   data: () => ({
     selectedType: 'event',
+    eventError: '',
   }),
   computed: {
     fields() {
@@ -103,6 +105,12 @@ export default {
     },
     async saveItem(data) {
       if (!data.name) {
+        this.eventError = 'name is a required field!'
+        return
+      }
+
+      if (!data.startDate) {
+        this.eventError = 'start date is not set!'
         return
       }
 

--- a/pages/events/_id/edit.vue
+++ b/pages/events/_id/edit.vue
@@ -17,7 +17,7 @@
         vertical
         :show-remove="!!item.id"
         :show-copy="!!item.id"
-        :event-error="eventError"
+        :errors="errors"
         submit-label="Save"
         class="bg-white p-4 space-y-4"
         @copy="copyItem"
@@ -50,7 +50,7 @@ export default {
   },
   data: () => ({
     selectedType: 'event',
-    eventError: {},
+    errors: [],
   }),
   computed: {
     fields() {
@@ -104,20 +104,32 @@ export default {
       this.$router.push(`/events/${doc.id}`)
     },
     async saveItem(data) {
-      if (!data.name) {
-        this.eventError = {
-          message: 'name is a required field!',
-          field: 'name',
+      if (!data.name || !data.startDate) {
+        this.errors = []
+        let error = {
+          message: '',
+          field: '',
         }
-        return
-      }
 
-      if (!data.startDate) {
-        this.eventError = {
-          message: 'start date is not set!',
-          field: 'startDate',
+        if (!data.name) {
+          error = {
+            message: 'name is a required field!',
+            field: 'name',
+          }
+          this.errors.push(error)
+          this.$toast.error(error.message)
         }
-        return
+
+        if (!data.startDate) {
+          error = {
+            message: 'start date is not set!',
+            field: 'startDate',
+          }
+          this.errors.push(error)
+          this.$toast.error(error.message)
+        }
+
+        return false
       }
 
       data.organisedBy = this.uid

--- a/pages/events/_id/edit.vue
+++ b/pages/events/_id/edit.vue
@@ -50,7 +50,7 @@ export default {
   },
   data: () => ({
     selectedType: 'event',
-    eventError: '',
+    eventError: {},
   }),
   computed: {
     fields() {
@@ -105,12 +105,18 @@ export default {
     },
     async saveItem(data) {
       if (!data.name) {
-        this.eventError = 'name is a required field!'
+        this.eventError = {
+          message: 'name is a required field!',
+          field: 'name',
+        }
         return
       }
 
       if (!data.startDate) {
-        this.eventError = 'start date is not set!'
+        this.eventError = {
+          message: 'start date is not set!',
+          field: 'startDate',
+        }
         return
       }
 


### PR DESCRIPTION
## Changes Made
- Can save an event without dance style
- A message is shown when the required fields name and startDate are not filled

## How to test
- Open https://wedance-amanuela97.netlify.app/events/_id/edit
- Save a new event without filling in name or start date and it should show an error message
- Try saving a new event without a dance style and it should work

Demo Link: https://wedance-amanuela97.netlify.app/

