### PR TITLE
chore: debug i18n

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -405,7 +405,6 @@ contacts:
   website: Website
 save: Save
 add: Add
-cancel: Cancel
 teaser:
   partner:
     title: Need a partner?
@@ -523,4 +522,3 @@ EventDashboard:
   subscribed: Subscribed
   paid: Paid
   notPaid: Didn't Pay
-  

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,6 +9,24 @@ export const app = {
   cover: '/cover/wide.png',
 }
 
+const locales = [
+  { code: 'en', name: 'English', file: 'en.yml' },
+  { code: 'es', name: 'Español', file: 'es.yml' },
+  { code: 'de', name: 'Deutsch', file: 'de.yml' },
+  { code: 'fr', name: 'Français', file: 'fr.yml' },
+  { code: 'it', name: 'Italiano', file: 'it.yml' },
+  { code: 'pl', name: 'Polski', file: 'pl.yml' },
+  { code: 'pt', name: 'Português', file: 'pt.yml' },
+  { code: 'ro', name: 'Română', file: 'ro.yml' },
+  { code: 'tr', name: 'Türkçe', file: 'tr.yml' },
+  { code: 'ru', name: 'Русский', file: 'ru.yml' },
+  { code: 'sr', name: 'Српски', file: 'sr.yml' },
+]
+
+if (process.env.DEBUG_I18N) {
+  locales.push({ code: 'debug', name: 'DEBUG', file: 'debug.yml' })
+}
+
 export default {
   target: 'static',
   ssr: false,
@@ -196,25 +214,13 @@ export default {
     routes: ['/'],
   },
   i18n: {
-    locales: [
-      { code: 'en', name: 'English', file: 'en.yml' },
-      { code: 'es', name: 'Español', file: 'es.yml' },
-      { code: 'de', name: 'Deutsch', file: 'de.yml' },
-      { code: 'fr', name: 'Français', file: 'fr.yml' },
-      { code: 'it', name: 'Italiano', file: 'it.yml' },
-      { code: 'pl', name: 'Polski', file: 'pl.yml' },
-      { code: 'pt', name: 'Português', file: 'pt.yml' },
-      { code: 'ro', name: 'Română', file: 'ro.yml' },
-      { code: 'tr', name: 'Türkçe', file: 'tr.yml' },
-      { code: 'ru', name: 'Русский', file: 'ru.yml' },
-      { code: 'sr', name: 'Српски', file: 'sr.yml' },
-    ],
+    locales,
     defaultLocale: 'en',
     strategy: 'no_prefix',
     lazy: true,
     langDir: 'locales/',
     vueI18n: {
-      fallbackLocale: 'en',
+      fallbackLocale: process.env.DEBUG_I18N ? 'debug' : 'en',
     },
     detectBrowserLanguage: {
       useCookie: true,


### PR DESCRIPTION
Set environment variable `DEBUG_I18N=1` to activate i18n debugging mode:
- it will add a new language "DEBUG" in language picker
- fallback language will be set to empty debug dictionary
- all strings translations will be shown as keys

Demo: https://wedance-razbakov.netlify.app/

![Screenshot 2022-02-08 at 14 16 19](https://user-images.githubusercontent.com/298778/152994801-e86d286c-1ed2-4303-a6d4-b93778c706e5.png)

