### PR TITLE
WeDanceBot: configure Telegram channel for any city

### DIFF
--- a/pages/admin/cities.vue
+++ b/pages/admin/cities.vue
@@ -61,11 +61,8 @@ export default {
           name: 'name',
         },
         {
-          name: 'telegram',
-        },
-        {
           name: 'location',
-          component: 'TInputPlace',
+          component: 'TInputLocation',
         },
         {
           name: 'hits',
@@ -74,6 +71,24 @@ export default {
           name: 'status',
           component: 'TInputSelect',
           options: ['requested', 'active'],
+        },
+        {
+          name: 'ambassador',
+          component: 'TInputProfile',
+          label: 'Ambassador',
+          labelPosition: 'top',
+        },
+        {
+          name: 'instagram',
+        },
+        {
+          name: 'telegram',
+        },
+        {
+          name: 'telegramChannel',
+        },
+        {
+          name: 'telegramChannelId',
         },
       ],
       filters: [

--- a/pages/events/_id/index.vue
+++ b/pages/events/_id/index.vue
@@ -149,10 +149,10 @@
     </div>
 
     <div
-      v-if="doc.telegram && doc.telegram.url"
+      v-if="doc.telegram && doc.telegram.messageUrl"
       class="mt-4 flex justify-center"
     >
-      <TButton type="link" :href="doc.telegram.url">
+      <TButton type="link" :href="doc.telegram.messageUrl">
         Announced on&nbsp;
         <TDateTime :value="doc.telegram.publishedAt" />
       </TButton>

--- a/services/firebase/src/cli.ts
+++ b/services/firebase/src/cli.ts
@@ -20,19 +20,24 @@ yargs(hideBin(process.argv))
     'Announce event',
     () => undefined,
     async (argv: any) => {
-      const chatId = '-1001764201490'
-      const chatUrl = 'https://t.me/+8l4IEhNjT3xlODNi'
+      const eventRef = await firestore
+        .collection('posts')
+        .doc(argv.eventId)
+        .get()
 
-      const event = (
-        await firestore
-          .collection('posts')
-          .doc(argv.eventId)
-          .get()
-      ).data() as any
+      const event = { ...eventRef.data(), id: eventRef.id }
+      const result = await announceEvent(event, {
+        chatId: '-1001764201490',
+        chatUrl: 'https://t.me/+8l4IEhNjT3xlODNi',
+      })
 
-      const result = await announceEvent(chatId, event)
+      if (!result) {
+        return
+      }
 
-      console.log(`Posted at ${chatUrl}/${result.message_id} at ${result.date}`)
+      const date = new Date(result.publishedAt)
+
+      console.log(`Posted at ${result.messageUrl} at ${date}`)
     }
   )
   .command(

--- a/services/firebase/src/lib/telegram.ts
+++ b/services/firebase/src/lib/telegram.ts
@@ -35,6 +35,11 @@ async function announceEvent(event: any, options: any = null) {
   const chatId = options?.chatId || city.channelId
   const chatUrl = options?.chatUrl || city.telegramChannel
 
+  if (!chatId) {
+    console.log(`Bot is not present in ${city.name}`)
+    return
+  }
+
   const response = await telegram.sendPhoto(chatId, photo, {
     caption,
   })

--- a/services/firebase/src/lib/telegram.ts
+++ b/services/firebase/src/lib/telegram.ts
@@ -1,7 +1,10 @@
 import { Telegram } from 'telegraf'
+import { firestore as db } from '../firebase'
+import { getDocs } from './migrations'
+
 require('dotenv').config()
 
-async function announceEvent(chatId: string, event: any) {
+async function announceEvent(event: any, options: any = null) {
   const token = String(process.env.TELEGRAM_BOT_TOKEN)
   const telegram = new Telegram(token)
 
@@ -16,13 +19,37 @@ async function announceEvent(chatId: string, event: any) {
   }
 
   const photo = event.socialCover
-  const caption = `${hashtags}\n\n${description}\nhttps://wedance.vip/${event.org.username}`
+  const caption = `${hashtags}\n\n${description}\n\nhttps://wedance.vip/events/${event.id}`
+
+  const cities = await getDocs(
+    db.collection('cities').where('location.place_id', '==', event.place)
+  )
+
+  if (!cities.length) {
+    console.log(`Community ${event.place} not found`)
+    return
+  }
+
+  const city = cities[0]
+
+  const chatId = options?.chatId || city.channelId
+  const chatUrl = options?.chatUrl || city.telegramChannel
 
   const response = await telegram.sendPhoto(chatId, photo, {
     caption,
   })
 
-  return response
+  const messageId = response.message_id
+  const messageUrl = `${chatUrl}/${messageId}`
+  const publishedAt = +new Date()
+
+  return {
+    chatId,
+    chatUrl,
+    messageId,
+    messageUrl,
+    publishedAt,
+  }
 }
 
 export { announceEvent }


### PR DESCRIPTION
As an Ambassador I want to configure my telegram channel so that I can announce events in any city

- configure `chatId`, `chatUrl`, `ambassador` in `/admin/cities` and use instead of hardcoded values
- overwrite `chatId`, `chatUrl` via options in `announceEvent(event: any, options: any = null)`
- log if city or chat not configured
- announce with link to the event instead of the organizer's profile
- use `telegram.messageUrl` instead of `telegram.url`
- use `telegram.messageId` instead of `telegram.id`