### PR TITLE
fix: update .eslintrc rules to fix build locally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
   rules: {
     'no-console': 'off',
     'vue/no-v-html': 'off',
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
   ignorePatterns: ['services'],
 }


### PR DESCRIPTION
`yarn run build` throws error to build the app locally. This happens due to .eslintrc rules. Updating the rules fix the issue.